### PR TITLE
Remove `use std::ascii::AsciiExt'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ extern crate time;
 mod base62;
 
 use std::io;
-use std::ascii::AsciiExt;
 
 use byteorder::{ByteOrder, BigEndian};
 use time::{Timespec, Duration};


### PR DESCRIPTION
AsciiExt trait is deprecated since rust 1.26 in favor of inherent
methods of the primitive types.