### PR TITLE
Upgrade to rand 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Dylan MacKenzie <ecstaticmorse@gmail.com>"]
 name = "ksuid"
-version = "0.1.0"
+version = "0.3.0"
 description = "A library for efficiently generating, parsing and serializing Segment.io KSUIDs"
 repository = "https://github.com/ecstatic-morse/ksuid.git"
 readme = "README.md"
@@ -10,7 +10,7 @@ license = "MIT"
 
 [dependencies]
 byteorder = "1.0.0"
-rand = "0.3.15"
+rand = "0.6.0"
 resize-slice = "0.1.2"
 time = "0.1.37"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Dylan MacKenzie <ecstaticmorse.gmail.com>"]
 name = "ksuid-cli"
-version = "0.1.0"
+version = "0.3.0"
 description = "A command line interface for generating, parsing, and serializing Segment.io KSUIDs"
 repository = "https://github.com/ecstatic-morse/ksuid.git"
 readme = "../README.md"
@@ -10,8 +10,7 @@ license = "MIT"
 
 [dependencies]
 docopt = "0.8.0"
-ksuid = { version="0.1.0", path = ".." }
-rand = "0.3.15"
+ksuid = { version="0.3.0", path = ".." }
 serde = "1.0.8"
 serde_derive = "1.0.8"
 time = "0.1.37"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,13 +4,11 @@ extern crate serde_derive;
 extern crate docopt;
 extern crate ksuid;
 extern crate time;
-extern crate rand;
 
 use std::io::{self, Write};
 use std::process::exit;
 
 use ksuid::Ksuid;
-use rand::Rng;
 
 const USAGE: &str = "
 ksuid
@@ -46,10 +44,8 @@ fn generate(args: Args) {
     let out = io::stdout();
     let mut locked = out.lock();
 
-    let mut rng = rand::thread_rng();
-
     for _ in 0..args.flag_count {
-        writeln!(&mut locked, "{}", rng.gen::<Ksuid>().to_base62()).unwrap();
+        writeln!(&mut locked, "{}", Ksuid::generate().to_base62()).unwrap();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ use std::ascii::AsciiExt;
 
 use byteorder::{ByteOrder, BigEndian};
 use time::{Timespec, Duration};
-use rand::{Rng, Rand};
+use rand::Rng;
+use rand::distributions::{Distribution, Standard};
 
 /// The KSUID epoch, 1.4 billion seconds after the UNIX epoch.
 ///
@@ -91,8 +92,7 @@ impl Ksuid {
     ///
     /// This function uses the thread local random number generator. this means that if you're
     /// calling `generate()` in a loop, caching the generator can increase performance. See the
-    /// documentation of [`rand::random()`](https://doc.rust-lang.org/rand/rand/fn.random.html) for
-    /// an example.
+    /// documentation of [`rand::random()`](rand::random) for an example.
     pub fn generate() -> Self {
         rand::random()
     }
@@ -227,9 +227,9 @@ impl Ksuid {
     }
 }
 
-impl Rand for Ksuid {
-    fn rand<R: Rng>(rng: &mut R) -> Self {
-        Self::with_payload(rng.gen())
+impl Distribution<Ksuid> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Ksuid {
+        Ksuid::with_payload(rng.gen())
     }
 }
 


### PR DESCRIPTION
Update to latest release. Better performance as a side effect.

Before:

    running 2 tests
    test tests::bench_gen                         ... bench:         159 ns/iter (+/- 3)
    test tests::bench_gen_lock_rng                ... bench:         155 ns/iter (+/- 2)

After:

    running 2 tests
    test tests::bench_gen                         ... bench:          74 ns/iter (+/- 2)
    test tests::bench_gen_lock_rng                ... bench:          72 ns/iter (+/- 4)

Bump version to 0.3.0 because Ksuid no longer impl Rand

The ksuid cli now uses public `Ksuid::generate()` interface so it
doesn't need to import rand crate directly.