### PR TITLE
Upgrade to docopt 1.0.0

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,8 +8,12 @@ readme = "../README.md"
 keywords = ["uuid", "ksuid", "guid"]
 license = "MIT"
 
+[[bin]]
+name = "ksuid"
+path = "src/main.rs"
+
 [dependencies]
-docopt = "0.8.0"
+docopt = "1.0.0"
 ksuid = { version="0.1.0", path = ".." }
 rand = "0.3.15"
 serde = "1.0.8"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,11 +16,13 @@ const USAGE: &str = "
 ksuid
 
 Usage:
-    ksuid [--count=<n>]
+    ksuid [-n <n> | --count=<n>]
     ksuid inspect <uids>...
+    ksuid -h | --help
 
 Options:
-    -n=<n>, --count=<n>  Number of KSUIDs to generate [default: 1]
+    -h, --help           Display this help and exit
+    -n <n>, --count=<n>  Number of KSUIDs to generate [default: 1]
 ";
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Rename the binary to match the canonical implementation `ksuid`
without `-cli` suffix.

Provide `-h | --help` switch to display the help message.

Document the `-n` shortcut for `--count`.